### PR TITLE
[dhcp-server] Change the kea-dhcp4 PID file directory to tmpfs.

### DIFF
--- a/dockers/docker-dhcp-server/supervisord.conf
+++ b/dockers/docker-dhcp-server/supervisord.conf
@@ -61,3 +61,4 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=dhcpservd:running
+environment=KEA_PIDFILE_DIR=/tmp/


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the issue with running "dhcp-server-ipv4:kea-dhcp4" process after a cold reboot: TODO issue number

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The root cause of the issue is that during the cold reboot, the PID file of the process (that is stored on the persisted FS) is not cleared. From the [KEA DHCP server documentation](https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html):

> If the file already exists and contains the PID of a live process, the server issues a DHCP4_ALREADY_RUNNING log message and exits. It is possible, though unlikely, that the file is a remnant of a system crash and the process to which the PID belongs is unrelated to Kea. In such a case, it would be necessary to manually delete the PID file.

To make sure that the PID file is always cleared during the dhcp-server container restart the PID file should be stored on the tmpfs. 

#### How to verify it

Go over the steps to reproduce described in (TODO issue number).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

