### PR TITLE
[build] Use configured architecture in the GRUB config.

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -588,13 +588,13 @@ menuentry '$demo_grub_entry' {
         if [ x$grub_platform = xxen ]; then insmod xzio; insmod lzopio; fi
         insmod part_msdos
         insmod ext2
-        $GRUB_CFG_LINUX_CMD   /$image_dir/boot/vmlinuz-6.1.0-11-2-amd64 root=$grub_cfg_root rw $GRUB_CMDLINE_LINUX  \
+        $GRUB_CFG_LINUX_CMD   /$image_dir/boot/vmlinuz-6.1.0-11-2-${arch} root=$grub_cfg_root rw $GRUB_CMDLINE_LINUX  \
                 net.ifnames=0 biosdevname=0 \
                 loop=$image_dir/$FILESYSTEM_SQUASHFS loopfstype=squashfs                       \
                 systemd.unified_cgroup_hierarchy=0 \
                 apparmor=1 security=apparmor varlog_size=$VAR_LOG_SIZE usbcore.autosuspend=-1 $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
         echo    'Loading $demo_volume_label $demo_type initial ramdisk ...'
-        $GRUB_CFG_INITRD_CMD  /$image_dir/boot/initrd.img-6.1.0-11-2-amd64
+        $GRUB_CFG_INITRD_CMD  /$image_dir/boot/initrd.img-6.1.0-11-2-${arch}
 }
 EOF
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -141,6 +141,8 @@ if [ "$install_env" = "onie" ]; then
     onie_initrd_tmp=/
 fi
 
+arch="%%ARCH%%"
+
 # The build system prepares this script by replacing %%DEMO-TYPE%%
 # with "OS" or "DIAG".
 demo_type="%%DEMO_TYPE%%"

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -97,6 +97,7 @@ output_raw_image=$(eval echo $output_raw_image)
 
 # Tailor the demo installer for OS mode or DIAG mode
 sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
+       -e "s/%%ARCH%%/$arch/g" \
        -e "s/%%IMAGE_VERSION%%/$image_version/g" \
        -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \
        -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The existing grub configuration has a hardcoded "amd64" architecture in the kernel and initramfs names. This causes an error in the attempt to load the image compiled for a different architecture.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use configured architecture in the GRUB config.

#### How to verify it
Compile the image for Arm64 architecture and install it on the device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

