### PR TITLE
[dhcp_server] Fix the issue with "kea-dhcp4.conf" file generation for Smart Switch.

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -90,7 +90,7 @@ class DhcpServCfgGenerator(object):
         port_ips, used_ranges = self._parse_port(port_ipv4, dhcp_interfaces, dhcp_members, ranges)
         customized_options = self._parse_customized_options(customized_options_ipv4)
         render_obj, enabled_dhcp_interfaces, used_options, subscribe_table = \
-            self._construct_obj_for_template(dhcp_server_ipv4, port_ips, hostname, customized_options)
+            self._construct_obj_for_template(dhcp_server_ipv4, port_ips, hostname, customized_options, smart_switch)
 
         if smart_switch:
             subscribe_table |= set(SMART_SWITCH_CHECKER)
@@ -175,7 +175,7 @@ class DhcpServCfgGenerator(object):
         for pc_name in pc_table.keys():
             self.port_alias_map[pc_name] = pc_name
 
-    def _construct_obj_for_template(self, dhcp_server_ipv4, port_ips, hostname, customized_options):
+    def _construct_obj_for_template(self, dhcp_server_ipv4, port_ips, hostname, customized_options, smart_switch=False):
         subnets = []
         client_classes = []
         enabled_dhcp_interfaces = set()
@@ -223,8 +223,9 @@ class DhcpServCfgGenerator(object):
                                 "condition": "substring(relay4[1].hex, -{}, {}) == '{}'".format(class_len, class_len,
                                                                                                 client_class)
                             })
+
                     subnet_obj = {
-                        "id": dhcp_interface_name.replace("Vlan", ""),
+                        "id": 0 if smart_switch else dhcp_interface_name.replace("Vlan", ""),
                         "subnet": str(ipaddress.ip_network(dhcp_interface_ip, strict=False)),
                         "pools": pools,
                         "gateway": dhcp_config["gateway"],

--- a/src/sonic-dhcp-utilities/tests/test_data/kea-dhcp4.conf.j2
+++ b/src/sonic-dhcp-utilities/tests/test_data/kea-dhcp4.conf.j2
@@ -42,6 +42,7 @@
     {%- if add_subnet_preceding_comma.flag -%},{%- endif -%}
     {%- set _dummy = add_subnet_preceding_comma.update({'flag': True}) %}
             {
+                "id": {{ subnet_info["id"] }},
                 "subnet": "{{ subnet_info["subnet"] }}",
                 "pools": [
     {%- set add_pool_preceding_comma = { 'flag': False } %}

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -42,6 +42,7 @@ expected_dhcp_config = {
         },
         "subnet4": [
             {
+                "id": 1000,
                 "subnet": "192.168.0.0/21",
                 "pools": [
                     {

--- a/src/sonic-dhcp-utilities/tests/test_smart_switch.py
+++ b/src/sonic-dhcp-utilities/tests/test_smart_switch.py
@@ -35,6 +35,7 @@ expected_kea_config = {
         },
         "subnet4": [
             {
+                "id": 0,
                 "subnet": "169.254.200.0/24",
                 "pools": [
                     {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The configuration generated from the template for the Smart Switch contained incorrect data in the "subnet4:id" field. For regular cases, the subnet ID is deduced from the VLAN name. For the Smart Switch, there is always one subnet, and the ID is set to 0.

```
"subnet4": [
        {
            "id": bridge-midplane,
            "subnet": "169.254.200.0/24",
            "pools": [
                {
                    "pool": "169.254.200.1 - 169.254.200.1",
                    "client-class": "sonic:dpu0"
                },
...
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix configuration generation for Smart Switch device.

#### How to verify it


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

