### PR TITLE
[Static DNS] Optimize DNS configuration update during interface-config service restart

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+resolvconf_updates=true
 
 function wait_networking_service_done() {
     local -i _WDOG_CNT="1"
@@ -22,6 +23,24 @@ function wait_networking_service_done() {
     echo "interfaces-config: networking service is still running after 30 seconds, killing it"
     systemctl kill networking 2>&1
 }
+
+function resolvconf_updates_disable() {
+    resolvconf --updates-are-enabled
+    if [[ $? -ne 0 ]]; then
+        resolvconf_updates=false
+    fi
+    resolvconf --disable-updates
+}
+
+function resolvconf_updates_restore() {
+    if [[ $resolvconf_updates == true ]]; then
+        resolvconf --enable-updates
+    fi
+}
+
+# Do not run DNS configuration update during the shutdowning of the management interface. 
+# This operation is redundant as there will be an update after the start of the interface.
+resolvconf_updates_disable
 
 if [[ $(ifquery --running eth0) ]]; then
     wait_networking_service_done
@@ -61,6 +80,8 @@ for intf_pid in $(ls -1 /var/run/dhclient*.Ethernet*.pid 2> /dev/null); do
 done
 
 /usr/bin/resolv-config.sh cleanup
+# Restore DNS configuration update to the previous state.
+resolvconf_updates_restore
 
 # Read sysctl conf files again
 sysctl -p /etc/sysctl.d/90-dhcp6-systcl.conf

--- a/files/image_config/resolv-config/update-containers
+++ b/files/image_config/resolv-config/update-containers
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-for container in $(docker ps -a --format=" {{ .ID }}"); do
+networking_status=$(systemctl is-active networking.service 2>/dev/null)
+if [[ $networking_status != "active" ]]; then
+    exit 0
+fi
+
+for container in $(docker ps -q); do
     docker cp -L /etc/resolv.conf ${container}:/_resolv.conf
     docker exec -t ${container} bash -c "cat /_resolv.conf > /etc/resolv.conf"
     docker exec -t ${container} bash -c "rm /_resolv.conf"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `resolvconfig` service updates the DNS configuration in the host OS and each running Docker container when a configuration change is detected. The DNS configuration update during the shutdown of the management interface is redundant, as the management interface is going down temporarily and, when it is back online, the DNS configuration will remain the same. The update of the DNS configuration adds a couple of seconds (depending on the CPU) to the interface-config service restart time when the management interface uses a dynamic IP address. This can affect the fast boot. To optimize the flow and execute the service restart faster, the update should be skipped.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Do not run DNS configuration update during the shutdown of the management interface.

#### How to verify it
Measure the execution time of the `service interfaces-config restart` command on the device with the static IP address configuration on the management interface and compare it to the execution time of the same command with the dynamic IP address. The difference should be insignificant.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

