### PR TITLE
[Mellanox] Update mlnx-fw-upgrade.j2 to support BF3 DPU NIC FW.

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -36,6 +36,7 @@ declare -r VERBOSE_MIN="${VERBOSE_ERROR}"
 declare -r EXIT_SUCCESS="0"
 declare -r EXIT_FAILURE="1"
 declare -r FW_ALREADY_UPDATED_FAILURE="2"
+declare -r FW_UPGRADE_IS_REQUIRED="10"
 
 declare -r QUERY_XML="mlxfwmanager --query-format XML"
 declare -r QUERY_CMD="mlxfwmanager --query"
@@ -49,6 +50,7 @@ declare -r SPC1_ASIC="spc1"
 declare -r SPC2_ASIC="spc2"
 declare -r SPC3_ASIC="spc3"
 declare -r SPC4_ASIC="spc4"
+declare -r BF3_NIC="bf3"
 declare -r UNKN_ASIC="unknown"
 declare -r UNKN_MST="unknown"
 
@@ -57,8 +59,10 @@ declare -rA FW_FILE_MAP=( \
     [$SPC2_ASIC]="fw-SPC2.mfa" \
     [$SPC3_ASIC]="fw-SPC3.mfa" \
     [$SPC4_ASIC]="fw-SPC4.mfa" \
+    [$BF3_NIC]="fw-BF3.mfa" \
 )
 
+DRY_RUN="${NO_PARAM}"
 IMAGE_UPGRADE="${NO_PARAM}"
 SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
@@ -72,6 +76,7 @@ function PrintHelp() {
     echo "  -u, --upgrade  Upgrade ASIC firmware using next boot image (useful after SONiC-To-SONiC update)"
     echo "  -s, --syslog   Use syslog logger (enabled when -u|--upgrade)"
     echo "  -v, --verbose  Verbose mode (enabled when -u|--upgrade)"
+    echo "  -d, --dry-run  Compare the FW versions without installation. Return code "0" means the FW is up-to-date, return code "10" means an upgrade is required, otherwise an error is detected."
     echo "  -h, --help     Print help"
     echo
     echo "Examples:"
@@ -94,6 +99,9 @@ function ParseArguments() {
             ;;
             -s|--syslog)
                 SYSLOG_LOGGER="${YES_PARAM}"
+            ;;
+            -d|--dry-run)
+                DRY_RUN="${YES_PARAM}"
             ;;
             -h|--help)
                 PrintHelp
@@ -179,9 +187,29 @@ function UnlockStateChange() {
     /usr/bin/flock -u ${LOCKFD}
 }
 
+function GetMstDeviceType() {
+    local -r asic_type=$(GetAsicType)
+
+    case $asic_type in
+    ${SPC1_ASIC}|${SPC2_ASIC}|${SPC3_ASIC}|${SPC4_ASIC})
+        echo "Spectrum"
+        return ${EXIT_SUCCESS}
+        ;;
+    ${BF3_NIC})
+        echo "BlueField3"
+        return ${EXIT_SUCCESS}
+        ;;
+    *)
+        echo "Unknown"
+        return ${EXIT_FAILURE}
+        ;;
+    esac
+}
+
 function WaitForDevice() {
     local -i QUERY_RETRY_COUNT_MAX="10"
     local -i QUERY_RETRY_COUNT="0"
+    local -r DEVICE_TYPE=$(GetMstDeviceType)
 
     local SPC_MST_DEV=$(GetSPCMstDevice)
 
@@ -198,7 +226,7 @@ function WaitForDevice() {
         ExitFailure "FW Query command: ${QUERY_CMD} failed to detect spectrum device with error: ${failure_msg}"
     fi
 
-    LogInfo "Spectrum ASIC successfully detected at ${SPC_MST_DEV}"
+    LogInfo "${DEVICE_TYPE} ASIC successfully detected at ${SPC_MST_DEV}"
 }
 
 function GetAsicType() {
@@ -208,6 +236,7 @@ function GetAsicType() {
     local -r SPC2_PRODUCT_ID="cf6c"
     local -r SPC3_PRODUCT_ID="cf70"
     local -r SPC4_PRODUCT_ID="cf80"
+    local -r BF3_PRODUCT_ID="a2dc"
 
     if lspci -n | grep "${VENDOR_ID}:${SPC1_PRODUCT_ID}" &>/dev/null; then
         echo "${SPC1_ASIC}"
@@ -221,6 +250,9 @@ function GetAsicType() {
     elif lspci -n | grep "${VENDOR_ID}:${SPC4_PRODUCT_ID}" &>/dev/null; then
         echo "${SPC4_ASIC}"
         exit "${EXIT_SUCCESS}"
+    elif lspci -n | grep "${VENDOR_ID}:${BF3_PRODUCT_ID}" &>/dev/null; then
+        echo "${BF3_NIC}"
+        exit "${EXIT_SUCCESS}"
     fi
 
     echo "${UNKN_ASIC}"
@@ -228,7 +260,8 @@ function GetAsicType() {
 }
 
 function GetSPCMstDevice() {
-    local _MST_DEVICE=$(${QUERY_XML} | xmlstarlet sel -t -m "//Device[contains(@type,'Spectrum')]" -v @pciName | head -n 1)
+    local _DEVICE_TYPE=$(GetMstDeviceType)
+    local _MST_DEVICE=$(${QUERY_XML} | xmlstarlet sel -t -m "//Device[contains(@type,'${_DEVICE_TYPE}')]" -v @pciName | head -n 1)
 
     if [[ ! -c "${_MST_DEVICE}" ]]; then
         echo "${UNKN_MST}"
@@ -267,6 +300,8 @@ function RunCmd() {
     fi
 }
 
+{% if sonic_asic_platform == "mellanox" %}
+
 function RunFwUpdateCmd() {
     local ERROR_CODE="${EXIT_SUCCESS}"
     local COMMAND="${MFT_DIAGNOSIS_FLAGS} ${BURN_CMD} $@"
@@ -301,6 +336,56 @@ function RunFwUpdateCmd() {
     fi
 }
 
+function GetAvailableFwVersion() {
+    local -r _FW_FILE="$1"
+    local -r _MST_DEVICE="$2"
+    local -r _PSID="$3"
+
+    RunCmd "${LIST_CONTENT_CMD} -i ${_FW_FILE} -d ${_MST_DEVICE} -o ${LIST_CONTENT_FILE}"
+
+    local -r _FW_AVAILABLE_INFO="$(grep ${_PSID} ${LIST_CONTENT_FILE})"
+    local -r _FW_AVAILABLE="$(echo ${_FW_AVAILABLE_INFO} | awk '{print $4}')"
+
+    echo ${_FW_AVAILABLE}
+}
+
+{% elif sonic_asic_platform == "nvidia-bluefield" %}
+
+function RunFwUpdateCmd() {
+    local ERROR_CODE="${EXIT_SUCCESS}"
+    local -r _MST_DEVICE="$(GetSPCMstDevice)"
+
+    # Reactivate FW prior to burning...
+    eval "flint -d ${_MST_DEVICE} ir" 2>&1 >/dev/null
+
+    local COMMAND="${MFT_DIAGNOSIS_FLAGS} flint $@ burn"
+
+    output=$(eval "${COMMAND}")
+
+    ERROR_CODE="$?"
+
+    if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        echo "${output}"
+        failure_msg="${output#*Fail : }"
+        ExitFailure "FW Update command: ${COMMAND} failed with error: ${failure_msg}"
+    fi
+}
+
+function GetAvailableFwVersion() {
+    local -r _FW_FILE="$1"
+    local -r _MST_DEVICE="$2"
+    local -r _PSID="$3"
+
+    RunCmd "flint -i ${_FW_FILE} --psid ${_PSID} query 2>&1 > ${LIST_CONTENT_FILE}"
+
+    local -r _FW_AVAILABLE_INFO="$(grep 'FW Version:' ${LIST_CONTENT_FILE})"
+    local -r _FW_AVAILABLE="$(echo ${_FW_AVAILABLE_INFO} | awk '{print $3}')"
+
+    echo ${_FW_AVAILABLE}
+}
+
+{% endif %}
+
 function UpgradeFW() {
     local -r _FW_BIN_PATH="$1"
 
@@ -323,10 +408,7 @@ function UpgradeFW() {
     RunCmd "${QUERY_XML} -d ${_MST_DEVICE} -o ${QUERY_FILE}"
     local -r _FW_CURRENT=$(GetXPathXML "//Device/Versions/FW/@current" ${QUERY_FILE})
     local -r _PSID=$(GetXPathXML "//Device/@psid" ${QUERY_FILE})
-
-    RunCmd "${LIST_CONTENT_CMD} -i ${_FW_FILE} -d ${_MST_DEVICE} -o ${LIST_CONTENT_FILE}"
-    local -r _FW_AVAILABLE_INFO="$(grep ${_PSID} ${LIST_CONTENT_FILE})"
-    local -r _FW_AVAILABLE="$(echo ${_FW_AVAILABLE_INFO} | awk '{print $4}')"
+    local -r _FW_AVAILABLE="$(GetAvailableFwVersion ${_FW_FILE} ${_MST_DEVICE} ${_PSID})"
 
     if [[ -z "${_FW_CURRENT}" ]]; then
         ExitFailure "could not retreive current FW version"
@@ -339,7 +421,13 @@ function UpgradeFW() {
     if [[ "${_FW_CURRENT}" == "${_FW_AVAILABLE}" ]]; then
         ExitSuccess "firmware is up to date"
     else
+        if [[ "${DRY_RUN}" == "${YES_PARAM}" ]]; then
+            LogNotice "firmware upgrade is required"
+            exit ${FW_UPGRADE_IS_REQUIRED}
+        fi
+
         LogNotice "firmware upgrade is required. Installing compatible version..."
+
         if [[ "${_MST_DEVICE}" = "${UNKN_MST}" ]]; then
             LogWarning "could not find fastest mst device, using default device"
             RunFwUpdateCmd "-i ${_FW_FILE}"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Extend `mlnx-fw-upgrade.j2` to support the upgrade of the DPU NIC FW

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add support for the new device to the script

#### How to verify it
Compile and install an image

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

