### PR TITLE
[Mellanox] Fix the issue with sensors with discrete indexes initialization

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -173,7 +173,10 @@ def initialize_chassis_thermals():
                 thermal_list.append(create_indexable_thermal(rule, index, CHASSIS_THERMAL_SYSFS_FOLDER, position))
                 position += 1
         elif thermal_type == 'discrete':
-            thermal_list.extend(create_discrete_thermal(rule))
+            discrete_thermals = create_discrete_thermal(rule, position)
+            if discrete_thermals:
+                position += len(discrete_thermals)
+                thermal_list.extend(discrete_thermals)
         else:
             thermal_object = create_single_thermal(rule, CHASSIS_THERMAL_SYSFS_FOLDER, position)
             if thermal_object:
@@ -280,10 +283,9 @@ def create_single_thermal(rule, sysfs_folder, position, presence_cb=None):
         return RemovableThermal(name, temp_file, high_th_file, high_crit_th_file, high_th_default, high_crit_th_default, scale, position, presence_cb)
 
 
-def create_discrete_thermal(rule):
+def create_discrete_thermal(rule, position):
     search_pattern = rule.get('search_pattern')
     index_pattern = rule.get('index_pattern')
-    position = 1
     thermal_list = []
     for file_path in glob.iglob(search_pattern):
         file_name = os.path.basename(file_path)


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the issue with the position calculation of the sensors with discrete indexes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Pass the base position into `create_discrete_thermal` function instead of initializing the position with 1.

#### How to verify it
Run `snmp/test_snmp_phy_entity.py` sonic-mgmt test on the platform with discrete sensors.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

