### PR TITLE
[Mellanox] Do not stop MST drivers during syncd stop

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -136,7 +136,6 @@ function stopplatform2() {
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         if [ x$sonic_asic_platform == x'mellanox' ]; then
             /etc/init.d/sxdkernel stop
-            /usr/bin/mst stop
         elif [ x"$sonic_asic_platform" == x"nvidia-bluefield" ]; then
             /usr/bin/bfnet.sh stop
         fi

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -90,9 +90,9 @@ function PrintHelp() {
     echo "Examples:"
     echo "  ./${SCRIPT_NAME} --verbose"
     echo "  ./${SCRIPT_NAME} --upgrade"
-    echo "  ./${SCRIPT_NAME} --no-mst"
 {% if sonic_asic_platform == "nvidia-bluefield" %}
     echo "  ./${SCRIPT_NAME} --reset"
+    echo "  ./${SCRIPT_NAME} --no-mst"
 {% endif %}
     echo "  ./${SCRIPT_NAME} --help"
     echo
@@ -239,10 +239,6 @@ function WaitForDevice() {
     if [[ "${NO_MST}" != "${YES_PARAM}" ]]; then
         LogInfo "Restarting MST device"
         /usr/bin/mst restart --with_i2cdev
-        ERROR_CODE="$?"
-        if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
-            ExitFailure "MST device restart failed with error: ${ERROR_CODE}"
-        fi
     fi
 
     while : ; do
@@ -266,15 +262,11 @@ function WaitForDevice() {
 }
 
 function GetSPCMstDevice() {
-    local _DEVICE_TYPE=$(GetMstDeviceType)
-    local _MST_DEVICE=$(${QUERY_XML} | xmlstarlet sel -t -m "//Device[contains(@type,'${_DEVICE_TYPE}')]" -v @pciName | head -n 1)
-
-    if [[ ! -c "${_MST_DEVICE}" ]]; then
-        echo "${UNKN_MST}"
-    else
-        echo "${_MST_DEVICE}"
+    local -r _ASIC_PCI_ID="$(/usr/bin/asic_detect/asic_detect.sh -p)"
+    if [[ "${_ASIC_PCI_ID}" = "${UNKN_PCI_ID}" ]]; then
+        ExitFailure "failed to detect ASIC PCI ID"
     fi
-
+    echo "${_ASIC_PCI_ID}"
     exit "${EXIT_SUCCESS}"
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Related to: TODO

State of MST drivers is controlled by the mlnx-fw-upgrade.sh script. Stopping drivers from syncd.sh script creates race conditions that can cause errors during the config reload.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Do not stop MST drivers from syncd.sh

#### How to verify it
Run sonic-mgmt tests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

